### PR TITLE
changed _strdup to qstrdup to fix build issue

### DIFF
--- a/src/qicruntime/qicruntime.cpp
+++ b/src/qicruntime/qicruntime.cpp
@@ -90,7 +90,7 @@ struct qicContextImpl : public qicContext
     void *set(void *ptr, const char *name, void(*deleter)(void*)) override
     {
         Q_ASSERT(frames.empty() == false);
-        frames.back().vars.push_back({ ptr, ::_strdup(name), deleter });
+        frames.back().vars.push_back({ ptr, ::qstrdup(name), deleter });
         return ptr;
     }
 


### PR DESCRIPTION
Using Ubuntu 20.04.3 and Qt6.2.2, I wasn't able to compile the code so I changed _strdup to qstrdup and that fixed the problem.